### PR TITLE
Added Maximum TensorFlow version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setuptools.setup(
     version='1.0',
     packages=setuptools.find_packages(),
     install_requires=[
-        'tensorflow>=1.12.0',
+        'tensorflow>=1.12.0,<2.1.1',
     ]
 )


### PR DESCRIPTION
When using NASBench101 with TensorFlow 2.1.1, I received errors saying 

> module 'tensorflow_core._api.v2.train' has no attribute 'SessionRunHook'

After downgrading TensorFlow to 1.13.1, the issues were resolved.
I am not certain which versions of TensorFlow do work, but I know 2.1.1 doesn't.